### PR TITLE
Ensure rbac exist for uninstall job in case of failed installations

### DIFF
--- a/helm/designate-certmanager-webhook/templates/rbac.yaml
+++ b/helm/designate-certmanager-webhook/templates/rbac.yaml
@@ -62,8 +62,6 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": pre-delete
 rules:
   - apiGroups:
       - acme.syseleven.de
@@ -87,8 +85,6 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": pre-delete
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -102,20 +98,3 @@ subjects:
     kind: ServiceAccount
     name: {{ include "designate-certmanager-webhook.fullname" . }}
     namespace: {{ .Release.Namespace }}
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: {{ include "designate-certmanager-webhook.fullname" . }}
-    namespace: default
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "designate-certmanager-webhook.fullname" . }}
-  labels:
-    app: {{ include "designate-certmanager-webhook.name" . }}
-    chart: {{ include "designate-certmanager-webhook.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": pre-delete
-  namespace: default

--- a/helm/designate-certmanager-webhook/templates/rbac.yaml
+++ b/helm/designate-certmanager-webhook/templates/rbac.yaml
@@ -7,9 +7,6 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
 ---
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate.
@@ -24,9 +21,6 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    annotations:
-      "helm.sh/hook": pre-delete
-      "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,9 +42,6 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -60,6 +51,30 @@ subjects:
     kind: ServiceAccount
     name: {{ include "designate-certmanager-webhook.fullname" . }}
     namespace: {{ .Release.Namespace }}
+---
+# Grant cert-manager permission to validate using our apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "designate-certmanager-webhook.fullname" . }}:domain-solver
+  labels:
+    app: {{ include "designate-certmanager-webhook.name" . }}
+    chart: {{ include "designate-certmanager-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - acme.syseleven.de
+    resources:
+      - '*'
+    verbs:
+      - 'create'
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
 ---
 # Grant cert-manager permission to validate using our apiserver
 apiVersion: rbac.authorization.k8s.io/v1
@@ -97,6 +112,9 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -124,4 +142,7 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
   namespace: default

--- a/helm/designate-certmanager-webhook/templates/rbac.yaml
+++ b/helm/designate-certmanager-webhook/templates/rbac.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 ---
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate.
@@ -21,6 +24,9 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    annotations:
+      "helm.sh/hook": pre-delete
+      "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -42,6 +48,9 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -62,6 +71,9 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
 rules:
   - apiGroups:
       - acme.syseleven.de

--- a/helm/designate-certmanager-webhook/templates/rbac.yaml
+++ b/helm/designate-certmanager-webhook/templates/rbac.yaml
@@ -62,33 +62,8 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-rules:
-  - apiGroups:
-      - acme.syseleven.de
-    resources:
-      - '*'
-    verbs:
-      - 'create'
-  - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    verbs:
-      - '*'
----
-# Grant cert-manager permission to validate using our apiserver
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "designate-certmanager-webhook.fullname" . }}:domain-solver
-  labels:
-    app: {{ include "designate-certmanager-webhook.name" . }}
-    chart: {{ include "designate-certmanager-webhook.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
 rules:
   - apiGroups:
       - acme.syseleven.de
@@ -114,7 +89,6 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -144,5 +118,4 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
   namespace: default

--- a/helm/designate-certmanager-webhook/templates/uninstall.yaml
+++ b/helm/designate-certmanager-webhook/templates/uninstall.yaml
@@ -27,3 +27,61 @@ spec:
             - --ignore-not-found
             - apiservice
             - v1alpha1.acme.syseleven.de
+---
+# Grant cert-manager permission to validate using our apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+  labels:
+    app: {{ include "designate-certmanager-webhook.name" . }}
+    chart: {{ include "designate-certmanager-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+  - apiGroups:
+      - 'batch'
+      - 'extensions'
+    resources:
+      - 'jobs'
+    verbs:
+      - 'create'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+  labels:
+    app: {{ include "designate-certmanager-webhook.name" . }}
+    chart: {{ include "designate-certmanager-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "designate-certmanager-webhook.fullname" . }}
+    namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "designate-certmanager-webhook.fullname" . }}
+  labels:
+    app: {{ include "designate-certmanager-webhook.name" . }}
+    chart: {{ include "designate-certmanager-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+  namespace: default


### PR DESCRIPTION
Sometimes install of the helm chart fails which triggers the uninstall jobs but the job fails because the install failed to add the rbac needed for the uninstall job to be created