### PR TITLE
Remove space in secret.yaml template reference

### DIFF
--- a/helm/designate-certmanager-webhook/templates/secret.yaml
+++ b/helm/designate-certmanager-webhook/templates/secret.yaml
@@ -4,8 +4,8 @@ kind: Secret
 metadata:
   name: {{ default "cloud-credentials" .Values.credentialsSecret }}
   labels:
-    app: "{{ template "designate-certmanager-webhook.fullname " . }}"
-    chart: "{{ template "designate-certmanager-webhook.chart " . }}"
+    app: "{{ template "designate-certmanager-webhook.fullname" . }}"
+    chart: "{{ template "designate-certmanager-webhook.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 type: Opaque


### PR DESCRIPTION
The additional space breaks templating and deployment. I guess it's here by mistake?