### PR TITLE
Add quote to record value

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,8 +62,12 @@ func (c *designateDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) erro
 
 	var opts recordsets.CreateOpts
 	opts.Name = ch.ResolvedFQDN
-	opts.Records = []string{ch.Key}
 	opts.Type = "TXT"
+	if strings.HasPrefix(ch.Key, "\"") {
+		opts.Records = []string{ch.Key}
+	} else {
+		opts.Records = []string{strconv.Quote(ch.Key)}
+	}
 
 	_, err = recordsets.Create(c.client, allZones[0].ID, opts).Extract()
 	if err != nil {


### PR DESCRIPTION
Hey everybody! 

First of all a big thanks for providing the webhook implementation. 

I'm currently using it to deploy cert-manager and ran into an issue where the API returned `Attribute 'records' is invalid, 'TXT records missing starting quotation mark'`. To my knowledge, most of the times you don't need to add quotes since the service is doing it for you. In this case however the quotes seem to be mandatory.

Would this small adjustment work for you and still support your current setup? 