### PR TITLE
Remove unused bzr dependency to fix image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15.0-alpine AS build_deps
 
-RUN apk add --no-cache git bzr
+RUN apk add --no-cache git
 
 WORKDIR /workspace
 ENV GO111MODULE=on


### PR DESCRIPTION
It appears that golang:1.14-alpine and golang:1.15-alpine switched to alpine 3.12, which doesn't have bzr available ([issue](https://github.com/alpinelinux/docker-alpine/issues/87)).

This causes the docker build to break, because the Dockerfiles appear to attempt to install bzr.

It also appears that this dependency is unused since I did not find a reference to it.