### PR TITLE
Fix empty check in secret.yaml template

### DIFF
--- a/helm/designate-certmanager-webhook/templates/secret.yaml
+++ b/helm/designate-certmanager-webhook/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.openstack.username) and (ne .Values.openstack.username "") and (.Values.openstack.password) and (ne .Values.openstack.password "") }}
+{{- if and .Values.openstack.username .Values.openstack.password }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,22 +10,22 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  {{- if (.Values.openstack.username) and (ne .Values.openstack.username "") }}
+  {{- if .Values.openstack.username }}
   OS_USERNAME: {{ .Values.openstack.username | b64enc | quote }}
   {{- end }}
-  {{- if (.Values.openstack.password) and (ne .Values.openstack.password "") }}
+  {{- if .Values.openstack.password }}
   OS_PASSWORD: {{ .Values.openstack.password | b64enc | quote }}
   {{- end }}
-  {{- if (.Values.openstack.project_id) and (ne .Values.openstack.project_id "") }}
+  {{- if .Values.openstack.project_id }}
   OS_PROJECT_ID: {{ .Values.openstack.project_id | b64enc | quote }}
   {{- end }}
-  {{- if (.Values.openstack.region_name) and (ne .Values.openstack.region_name "") }}
+  {{- if .Values.openstack.region_name }}
   OS_REGION_NAME: {{ .Values.openstack.region_name | b64enc | quote }}
   {{- end }}
-  {{- if (.Values.openstack.auth_url) and (ne .Values.openstack.auth_url "") }}
+  {{- if .Values.openstack.auth_url }}
   OS_AUTH_URL: {{ .Values.openstack.auth_url | b64enc | quote }}
   {{- end }}
-  {{- if (.Values.openstack.domain_name) and (ne .Values.openstack.domain_name "") }}
+  {{- if .Values.openstack.domain_name }}
   OS_DOMAIN_NAME: {{ .Values.openstack.domain_name | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
There are two issues with empty checks in the _secret.yaml_ template:

1) The _and_ operator is placed between the two values, but should be used as a method in front of the two parameters. Helm 3.3+(Go 1.14+ to be precise) [throws an error now](https://github.com/helm/helm/issues/7711).

2) If you check values with `if (.Values.openstack.username)` missing values (_nil_) as well as empty strings are considered true. So you do not need the additional check here.