### PR TITLE
Use release namespace by default for ClusterRoleBinding

### DIFF
--- a/helm/designate-certmanager-webhook/Chart.yaml
+++ b/helm/designate-certmanager-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.12"
 description: ACME webhook Implementation for OpenStack Designate
 name: designate-certmanager-webhook
-version: "0.2.12"
+version: "0.2.13"

--- a/helm/designate-certmanager-webhook/templates/rbac.yaml
+++ b/helm/designate-certmanager-webhook/templates/rbac.yaml
@@ -93,7 +93,7 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ .Values.certManager.serviceAccountName }}
-    namespace: {{ .Values.certManager.namespace }}
+    namespace: {{ .Values.certManager.namespace | default .Release.Namespace }}
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ include "designate-certmanager-webhook.fullname" . }}

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 certManager:
-  namespace: cert-manager
+  namespace: ~
   serviceAccountName: cert-manager
 
 image:


### PR DESCRIPTION
This switches the default of the cert-manager namespace to the namespace
this release is going to be installed while still maintaing configurability.
This makes it easier to use a custom namespace for cert-manager because
designate-certmanager-webhook will most certainly just be installed in
the same namespace as cert-manager.