### PR TITLE
App credential support

### DIFF
--- a/helm/designate-certmanager-webhook/templates/secret.yaml
+++ b/helm/designate-certmanager-webhook/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.openstack.application_credential_name .Values.openstack.application_credential_secret }}
+{{- if or .Values.openstack.username .Values.openstack.application_credential_name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,6 +10,18 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
+ {{- if .Values.openstack.username }}
+  OS_USERNAME: {{ .Values.openstack.username | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.openstack.password }}
+  OS_PASSWORD: {{ .Values.openstack.password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.openstack.project_id }}
+  OS_PROJECT_ID: {{ .Values.openstack.project_id | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.openstack.project_name }}
+  OS_PROJECT_NAME: {{ .Values.openstack.project_name | b64enc | quote }}
+  {{- end }}
   {{- if .Values.openstack.application_credential_name }}
   OS_APPLICATION_CREDENTIAL_NAME: {{ .Values.openstack.application_credential_name | b64enc | quote }}
   {{- end }}

--- a/helm/designate-certmanager-webhook/templates/secret.yaml
+++ b/helm/designate-certmanager-webhook/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.openstack.username .Values.openstack.password }}
+{{- if and .Values.openstack.application_credential_name .Values.openstack.application_credential_secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,18 +10,14 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  {{- if .Values.openstack.username }}
-  OS_USERNAME: {{ .Values.openstack.username | b64enc | quote }}
+  {{- if .Values.openstack.application_credential_name }}
+  OS_APPLICATION_CREDENTIAL_NAME: {{ .Values.openstack.application_credential_name | b64enc | quote }}
   {{- end }}
-  {{- if .Values.openstack.password }}
-  OS_PASSWORD: {{ .Values.openstack.password | b64enc | quote }}
+  {{- if .Values.openstack.application_credential_secret }}
+  OS_APPLICATION_CREDENTIAL_SECRET: {{ .Values.openstack.application_credential_secret | b64enc | quote }}
   {{- end }}
-  {{- if .Values.openstack.project_id }}
-  OS_PROJECT_ID: {{ .Values.openstack.project_id | b64enc | quote }}
-  {{- else if .Values.openstack.project_name }}
-  OS_PROJECT_NAME: {{ .Values.openstack.project_name | b64enc | quote }}
-  {{- else }}
-  {{- fail "project_id or project_name is needed!" }}
+  {{- if .Values.openstack.application_credential_id }}
+  OS_APPLICATION_CREDENTIAL_ID: {{ .Values.openstack.application_credential_id | b64enc | quote }}
   {{- end }}
   {{- if .Values.openstack.region_name }}
   OS_REGION_NAME: {{ .Values.openstack.region_name | b64enc | quote }}

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -23,14 +23,20 @@ credentialsSecret: cloud-credentials
 # If you fill out these information the helm chart will use your provided
 # information and overwrite an existing ${credentialsSecret} secret. If the values
 # are kept empty, you must create a secret with desired values manually. Please
-# refer to the README for more information.
+# refer to the README for more information. You may use either the application credentials.
+# Or the username and password combination to authenticate.
+# The username and password also require a projectid or name. Do not set the projectid if you are using application credentials.
 openstack:
-  application_credential_name: ""
-  application_credential_id: ""
-  application_credential_secret: ""
   region_name: ""
   auth_url: ""
   domain_name: ""
+  application_credential_name: ""
+  application_credential_id: ""
+  application_credential_secret: ""
+#  username: ""
+#  password: ""
+#  project_id: ""
+#  project_name: "" # Use project_id OR project_name
 
 nameOverride: ""
 fullnameOverride: ""

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -25,10 +25,9 @@ credentialsSecret: cloud-credentials
 # are kept empty, you must create a secret with desired values manually. Please
 # refer to the README for more information.
 openstack:
-  username: ""
-  password: ""
-  project_id: ""
-  project_name: "" # Use project_id OR project_name
+  application_credential_name: ""
+  application_credential_id: ""
+  application_credential_secret: ""
   region_name: ""
   auth_url: ""
   domain_name: ""


### PR DESCRIPTION
I added support for application credential to the chart template secret. I also updated the comment referring the secret to explain the two options to authenticate. 