### PR TITLE
Allow custom repo for kubectl container on unistall.yaml

### DIFF
--- a/helm/designate-certmanager-webhook/Chart.yaml
+++ b/helm/designate-certmanager-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.18"
 description: ACME webhook Implementation for OpenStack Designate
 name: designate-certmanager-webhook
-version: "0.3.0"
+version: "0.3.1"

--- a/helm/designate-certmanager-webhook/templates/uninstall.yaml
+++ b/helm/designate-certmanager-webhook/templates/uninstall.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: {{ include "designate-certmanager-webhook.fullname" . }}
       containers:
         - name: remove-apiservice
-          image: bitnami/kubectl:latest
+          image: "{{ .Values.image.kubectl.repository }}:{{ .Values.image.kubectl.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - kubectl


### PR DESCRIPTION
On deployment.yaml the option to set custom repo for kubectl container is already provided (and thus, default is already set on [values.yaml](https://github.com/syseleven/designate-certmanager-webhook/blob/master/helm/designate-certmanager-webhook/values.yaml#L14-L16) ), but on unistall.yaml it's not.