### PR TITLE
Helm chart container configuration restructure

### DIFF
--- a/helm/designate-certmanager-webhook/Chart.yaml
+++ b/helm/designate-certmanager-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.18"
 description: ACME webhook Implementation for OpenStack Designate
 name: designate-certmanager-webhook
-version: "0.3.2"
+version: "0.4.0"

--- a/helm/designate-certmanager-webhook/Chart.yaml
+++ b/helm/designate-certmanager-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.18"
 description: ACME webhook Implementation for OpenStack Designate
 name: designate-certmanager-webhook
-version: "0.3.1"
+version: "0.3.2"

--- a/helm/designate-certmanager-webhook/templates/deployment.yaml
+++ b/helm/designate-certmanager-webhook/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: {{ include "designate-certmanager-webhook.fullname" . }}
       initContainers:
         - name: wait-for-tls-secret
-          image: "{{ .Values.image.alpine.repository }}:{{ .Values.image.alpine.tag }}"
+          image: "{{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           - name: certs
@@ -38,7 +38,7 @@ spec:
             - -c
             - "while [ ! -f /tls/tls.key ]; do sleep 5; done"
         - name: add-apiservice
-          image: "{{ .Values.image.kubectl.repository }}:{{ .Values.image.kubectl.tag }}"
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: apiservice-config

--- a/helm/designate-certmanager-webhook/templates/uninstall.yaml
+++ b/helm/designate-certmanager-webhook/templates/uninstall.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: {{ include "designate-certmanager-webhook.fullname" . }}
       containers:
         - name: remove-apiservice
-          image: "{{ .Values.image.kubectl.repository }}:{{ .Values.image.kubectl.tag }}"
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - kubectl

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -8,10 +8,13 @@ image:
   repository: syseleven/designate-certmanager-webhook
   tag: 0.2.18
   pullPolicy: IfNotPresent
-  alpine:
+
+alpine:
+  image:
     repository: alpine
     tag: latest
-  kubectl:
+kubectl:
+  image:
     repository: bitnami/kubectl
     tag: latest
 


### PR DESCRIPTION
Restructure the configuration of the init containers and bump chart version.

This configuration is useful for automated updates of an image using renovate tool. 