### PR TITLE
Do not quote challenge in DNS recordset

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,6 @@ func (c *designateDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) erro
 	recordListOpts := recordsets.ListOpts{
 		Name: ch.ResolvedFQDN,
 		Type: "TXT",
-		Data: quoteRecord(ch.Key),
 	}
 
 	allRecordPages, err := recordsets.ListByZone(c.client, allZones[0].ID, recordListOpts).AllPages()
@@ -138,3 +137,4 @@ func (c *designateDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, s
 	c.client = cl
 	return nil
 }
+

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func (c *designateDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) erro
 	var opts recordsets.CreateOpts
 	opts.Name = ch.ResolvedFQDN
 	opts.Type = "TXT"
-	opts.Records = []string{quoteRecord(ch.Key)}
+	opts.Records = []string{ch.Key}
 
 	_, err = recordsets.Create(c.client, allZones[0].ID, opts).Extract()
 	if err != nil {
@@ -137,12 +137,4 @@ func (c *designateDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, s
 
 	c.client = cl
 	return nil
-}
-
-func quoteRecord(r string) string {
-	if strings.HasPrefix(r, "\"") && strings.HasSuffix(r, "\"") {
-		return r
-	} else {
-		return strconv.Quote(r)
-	}
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"


### PR DESCRIPTION
Actually, the quotes stay in the DNS recordset and therefore the challenge fail.

In example, we can have this kind of DNS entry in Designate:

`_acme.fake.test.fr. | TXT - Text record | "kRfT4AYwyt2amUAZtLDMaACI3GJg-TB6JDx_kU0OW6E"`

but we need to have:

`_acme.fake.test.fr. | TXT - Text record | kRfT4AYwyt2amUAZtLDMaACI3GJg-TB6JDx_kU0OW6E`

