### PR TITLE
Default identity-endpoint to v3 if application credentials will be used

### DIFF
--- a/designate.go
+++ b/designate.go
@@ -58,7 +58,7 @@ func getAuthSettings() (gophercloud.AuthOptions, error) {
 		opts.IdentityEndpoint += "/"
 	}
 	if !strings.HasSuffix(opts.IdentityEndpoint, "/v2.0/") && !strings.HasSuffix(opts.IdentityEndpoint, "/v3/") {
-		opts.IdentityEndpoint += "v2.0/"
+		opts.IdentityEndpoint += "v3/"
 	}
 	return opts, nil
 }


### PR DESCRIPTION
Application credentials need the api version 3 to be supported, thus default to `v3/` if no version has been specified in the url and application credentials have been passed.