### PR TITLE
add the ability to mount `OS_CACERT` for self-signed APIs

### DIFF
--- a/helm/designate-certmanager-webhook/templates/deployment.yaml
+++ b/helm/designate-certmanager-webhook/templates/deployment.yaml
@@ -85,6 +85,9 @@ spec:
             - name: certs
               mountPath: /tls
               readOnly: true
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12}}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:
@@ -97,6 +100,9 @@ spec:
           secret:
             optional: true
             secretName: {{ include "designate-certmanager-webhook.servingCertificate" . }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8}}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/designate-certmanager-webhook/templates/secret.yaml
+++ b/helm/designate-certmanager-webhook/templates/secret.yaml
@@ -40,6 +40,9 @@ data:
   {{- if .Values.openstack.domain_name }}
   OS_DOMAIN_NAME: {{ .Values.openstack.domain_name | b64enc | quote }}
   {{- end }}
+  {{- if .Values.openstack.ca_cert }}
+  OS_CACERT: {{ .Values.openstack.ca_cert | b64enc | quote }}
+  {{- end }}
   {{- if .Values.openstack.auth_type }}
   OS_AUTH_TYPE: {{ .Values.openstack.auth_type | b64enc | quote }}
   {{- end }}

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -37,6 +37,7 @@ openstack:
   region_name: ""
   auth_url: ""
   domain_name: ""
+  ca_cert: ""
 
 nameOverride: ""
 fullnameOverride: ""

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -39,6 +39,8 @@ openstack:
   domain_name: ""
   ca_cert: ""
 
+extraVolumes: []
+extraVolumeMounts: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Why?

In case your keystone has self-signed Certificates, you will have to specify the custom CA via the `OS_CACERT` (its actually `OPENSTACK_CA_FILE` here) environment variable. The `OS_CACERT` for auth requires gophercloud v2

Additionally I also added the option to provide the Pod with extraVolumes & Mounts since OS_CACERT has to be filepath not the content of the certificate

Relevant gophercloud code: https://github.com/gophercloud/gophercloud/blob/5cb81d730a1e027aa5981edd23c7b1403411db40/openstack/config/clouds/tls.go#L15