### PR TITLE
Make compatible with cloud-config of openstack cloud controller manag…

### DIFF
--- a/helm/designate-certmanager-webhook/templates/deployment.yaml
+++ b/helm/designate-certmanager-webhook/templates/deployment.yaml
@@ -64,9 +64,52 @@ spec:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
             - --secure-port=8443
-          envFrom:
-            - secretRef:
-                name: {{ .Values.credentialsSecret }}
+          env:
+            - name: OS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: username
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: password
+            - name: OS_APPLICATION_CREDENTIAL_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: application-credential-id
+            - name: OS_APPLICATION_CREDENTIAL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: application-credential-secret
+            - name: OS_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: tenant-id
+            - name: OS_PROJECT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: tenant-name
+            - name: OS_REGION_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: region
+            - name: OS_AUTH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: auth-url
+            - name: OS_DOMAIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentialsSecret }}
+                  key: domain-name
           ports:
             - name: https
               containerPort: 8443

--- a/helm/designate-certmanager-webhook/templates/secret.yaml
+++ b/helm/designate-certmanager-webhook/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ default "cloud-credentials" .Values.credentialsSecret }}
+  name: {{ default "cloud-config" .Values.credentialsSecret }}
   labels:
     app: "{{ template "designate-certmanager-webhook.fullname" . }}"
     chart: "{{ template "designate-certmanager-webhook.chart" . }}"
@@ -11,36 +11,33 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.openstack.username }}
-  OS_USERNAME: {{ .Values.openstack.username | b64enc | quote }}
+  username: {{ .Values.openstack.username | b64enc | quote }}
   {{- end }}
   {{- if .Values.openstack.password }}
-  OS_PASSWORD: {{ .Values.openstack.password | b64enc | quote }}
+  password: {{ .Values.openstack.password | b64enc | quote }}
   {{- end }}
   {{- if .Values.openstack.application_credential_id }}
-  OS_APPLICATION_CREDENTIAL_ID: {{ .Values.openstack.application_credential_id | b64enc | quote }}
+  application-credential-id: {{ .Values.openstack.application_credential_id | b64enc | quote }}
   {{- end }}
   {{- if .Values.openstack.application_credential_secret }}
-  OS_APPLICATION_CREDENTIAL_SECRET: {{ .Values.openstack.application_credential_secret | b64enc | quote }}
+  application-credential-secret: {{ .Values.openstack.application_credential_secret | b64enc | quote }}
   {{- end }}
   {{- if .Values.openstack.project_id }}
-  OS_PROJECT_ID: {{ .Values.openstack.project_id | b64enc | quote }}
+  tenant-id: {{ .Values.openstack.project_id | b64enc | quote }}
   {{- else if .Values.openstack.project_name }}
-  OS_PROJECT_NAME: {{ .Values.openstack.project_name | b64enc | quote }}
+  tenant-name: {{ .Values.openstack.project_name | b64enc | quote }}
   {{- else }}
     {{- if ne .Values.openstack.auth_type "v3applicationcredential" }}
       {{- fail "project_id or project_name is needed!" }}
     {{- end }}
   {{- end }}
   {{- if .Values.openstack.region_name }}
-  OS_REGION_NAME: {{ .Values.openstack.region_name | b64enc | quote }}
+  region: {{ .Values.openstack.region_name | b64enc | quote }}
   {{- end }}
   {{- if .Values.openstack.auth_url }}
-  OS_AUTH_URL: {{ .Values.openstack.auth_url | b64enc | quote }}
+  auth-url: {{ .Values.openstack.auth_url | b64enc | quote }}
   {{- end }}
   {{- if .Values.openstack.domain_name }}
-  OS_DOMAIN_NAME: {{ .Values.openstack.domain_name | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.openstack.auth_type }}
-  OS_AUTH_TYPE: {{ .Values.openstack.auth_type | b64enc | quote }}
+  domain-name: {{ .Values.openstack.domain_name | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -21,7 +21,7 @@ kubectl:
 imagePullSecrets: []
 
 # This secret holds the authenitcation information for designate
-credentialsSecret: cloud-credentials
+credentialsSecret: cloud-config # use same secret as openstack-cloud-controller-manager https://artifacthub.io/packages/helm/cloud-provider-openstack/openstack-cloud-controller-manager
 
 # If you fill out these information the helm chart will use your provided
 # information and overwrite an existing ${credentialsSecret} secret. If the values


### PR DESCRIPTION
Make compatible with cloud-config of openstack cloud controller manager… https://artifacthub.io/packages/helm/cloud-provider-openstack/openstack-cloud-controller-manager

**I will test it next week**

Simply rewrite deployment template, values template, and secret template, the goal was to keep the ability to create secret from the openstack section of the values file, but with ability to use existing cloud-config secret from the default openstack-cloud-controller-manager.