### PR TITLE
change base image kubectl from bitnami to k8s.io

### DIFF
--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -16,7 +16,7 @@ alpine:
 kubectl:
   image:
     repository: registry.k8s.io/kubectl
-    tag: latest
+    tag: v1.33.0
 
 imagePullSecrets: []
 

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -15,7 +15,7 @@ alpine:
     tag: latest
 kubectl:
   image:
-    repository: bitnami/kubectl
+    repository: registry.k8s.io/kubectl
     tag: latest
 
 imagePullSecrets: []


### PR DESCRIPTION
This pull request changes to value of `kubectl.image.repository` from `bitnami/kubectl` to `registry.k8s.io/kubectl`. 

The reason is the upcoming change on how to use [bitnami-images](https://github.com/bitnami/charts/issues/35164).