### PR TITLE
feat: publish helm charts into ghcr

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,22 @@
+name: Helm OCI Worklow
+
+on:
+  push:
+    tags:
+      - 'helm-*'
+
+jobs:
+  helm:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build and Push
+      run: |-
+        helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+        VERSION="${{ github.ref_name }}"
+        VERSION=${VERSION#"helm-"}
+        cd helm/designate-certmanager-webhook
+        helm package . --version ${VERSION}
+        helm push designate-certmanager-webhook-${VERSION}.tgz oci://ghcr.io/syseleven/helm


### PR DESCRIPTION
Publish helm chart as oci compliant blob into github container registry. This supports using the chart with an official downloader like oci.