### PR TITLE
fix: do not populate namespace twice

### DIFF
--- a/helm/designate-certmanager-webhook/templates/uninstall.yaml
+++ b/helm/designate-certmanager-webhook/templates/uninstall.yaml
@@ -8,7 +8,6 @@ metadata:
     chart: {{ include "designate-certmanager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded


### PR DESCRIPTION
The namespace should come from the helm template specification and not be hardcoded into the resource itself.