### PR TITLE
Fix ServiceAccount/ClusterRole name in uninstall template

### DIFF
--- a/helm/designate-certmanager-webhook/templates/uninstall.yaml
+++ b/helm/designate-certmanager-webhook/templates/uninstall.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+      serviceAccountName: {{ include "designate-certmanager-webhook.fullname" . }}-uninstall
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -36,7 +36,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+  name: {{ include "designate-certmanager-webhook.fullname" . }}-uninstall
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "designate-certmanager-webhook.name" . }}
@@ -63,7 +63,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+  name: {{ include "designate-certmanager-webhook.fullname" . }}-uninstall
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "designate-certmanager-webhook.name" . }}
@@ -76,17 +76,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+  name: {{ include "designate-certmanager-webhook.fullname" . }}-uninstall
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
-    name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+    name: {{ include "designate-certmanager-webhook.fullname" . }}-uninstall
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+  name: {{ include "designate-certmanager-webhook.fullname" . }}-uninstall
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "designate-certmanager-webhook.name" . }}


### PR DESCRIPTION
A colon is not a valid character to use in Kubernetes resource names, so this PR replaces the colon with a hyphen.

Fixes #95, which was supposed to be fixed by #117 

I've tagged and published the Helm chart in my fork to test it, and confirmed this fixes the issue for me: https://jonnyhaystack.github.io/designate-certmanager-webhook/

By the way, it seems that the README is outdated in stating that there is no Helm chart registry, as the GHCR OCI registry was in use for quite some time, and the GitHub Pages registry also exists. I'd be happy to make another PR to update those docs.