### PR TITLE
Add missing imagePullSecrets to uninstall job

### DIFF
--- a/helm/designate-certmanager-webhook/templates/uninstall.yaml
+++ b/helm/designate-certmanager-webhook/templates/uninstall.yaml
@@ -16,6 +16,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "designate-certmanager-webhook.fullname" . }}:uninstall
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/designate-certmanager-webhook/templates/uninstall.yaml
+++ b/helm/designate-certmanager-webhook/templates/uninstall.yaml
@@ -16,6 +16,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "designate-certmanager-webhook.fullname" . }}-uninstall
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:


### PR DESCRIPTION
Using a private custom registry for the kubectl image, via the `kubectl.image.repository` value (https://github.com/syseleven/designate-certmanager-webhook/blob/master/helm/designate-certmanager-webhook/values.yaml#L18), fails because the `imagePullSecrets` value is not respected for the uninstall Job.

This pull request updates `uninstall.yaml` to apply `imagePullSecrets` in the same way that it's already applied in `deployment.yaml`