### PR TITLE
Improve error handling with wrapped, contextual errors

### DIFF
--- a/designate.go
+++ b/designate.go
@@ -14,6 +14,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -51,7 +52,7 @@ func getAuthSettings() (gophercloud.AuthOptions, error) {
 
 	opts, err := openstack.AuthOptionsFromEnv()
 	if err != nil {
-		return gophercloud.AuthOptions{}, err
+		return gophercloud.AuthOptions{}, fmt.Errorf("failed to get auth options from env: %w", err)
 	}
 	opts.AllowReauth = true
 	if !strings.HasSuffix(opts.IdentityEndpoint, "/") {
@@ -67,17 +68,17 @@ func getAuthSettings() (gophercloud.AuthOptions, error) {
 func createDesignateServiceClient() (*gophercloud.ServiceClient, error) {
 	opts, err := getAuthSettings()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get auth settings: %w", err)
 	}
 	log.Infof("Using OpenStack Keystone at %s", opts.IdentityEndpoint)
 	authProvider, err := openstack.NewClient(opts.IdentityEndpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create auth provider: %w", err)
 	}
 
 	tlsConfig, err := tlsutils.CreateTLSConfig("OPENSTACK")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create TLS config: %w", err)
 	}
 
 	transport := &http.Transport{
@@ -95,7 +96,7 @@ func createDesignateServiceClient() (*gophercloud.ServiceClient, error) {
 	authProvider.HTTPClient.Transport = transport
 
 	if err = openstack.Authenticate(authProvider, opts); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to authenticate: %w", err)
 	}
 
 	eo := gophercloud.EndpointOpts{
@@ -104,7 +105,7 @@ func createDesignateServiceClient() (*gophercloud.ServiceClient, error) {
 
 	client, err := openstack.NewDNSV2(authProvider, eo)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create DNSV2 client: %w", err)
 	}
 	log.Infof("Found OpenStack Designate service at %s", client.Endpoint)
 	return client, nil

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type designateDNSProviderSolver struct {
 func New() webhook.Solver {
 	client, err := createDesignateServiceClient()
 	if err != nil {
-		panic(fmt.Errorf("%v", err))
+		log.Panic(fmt.Errorf("failed to create designate client: %w", err))
 	}
 	return &designateDNSProviderSolver{
 		client: client,
@@ -52,12 +52,12 @@ func (c *designateDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) erro
 
 	allPages, err := zones.List(c.client, listOpts).AllPages()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list zones: %w", err)
 	}
 
 	allZones, err := zones.ExtractZones(allPages)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to extract zones: %w", err)
 	}
 
 	if len(allZones) != 1 {
@@ -71,7 +71,7 @@ func (c *designateDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) erro
 
 	_, err = recordsets.Create(c.client, allZones[0].ID, opts).Extract()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create record set: %w", err)
 	}
 
 	return nil
@@ -86,12 +86,12 @@ func (c *designateDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) erro
 
 	allPages, err := zones.List(c.client, listOpts).AllPages()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list zones: %w", err)
 	}
 
 	allZones, err := zones.ExtractZones(allPages)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to extract zones: %w", err)
 	}
 
 	if len(allZones) != 1 {
@@ -107,12 +107,12 @@ func (c *designateDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) erro
 	allRecordPages, err := recordsets.ListByZone(c.client, allZones[0].ID, recordListOpts).AllPages()
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list record sets: %w", err)
 	}
 
 	allRRs, err := recordsets.ExtractRecordSets(allRecordPages)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to extract record sets: %w", err)
 	}
 
 	if len(allRRs) != 1 {
@@ -122,7 +122,7 @@ func (c *designateDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) erro
 	// TODO rather than deleting the whole recordset we may have to delete individual records from it, i.e. perform an update rather than a delete
 	err = recordsets.Delete(c.client, allZones[0].ID, allRRs[0].ID).ExtractErr()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete recordset: %w", err)
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func (c *designateDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, s
 
 	cl, err := createDesignateServiceClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create designate client: %w", err)
 	}
 
 	c.client = cl


### PR DESCRIPTION
All errors returned from OpenStack client setup (`getAuthSettings`, `createDesignateServiceClient`) and DNS operations (`Present`, `CleanUp`, `Initialize`) are now wrapped with `fmt.Errorf("...: %w", err)`, so log output and cert-manager challenge events state *which* step failed (auth, zone listing, recordset create/delete) instead of surfacing a bare gophercloud error. `%w` keeps the originals unwrappable via `errors.Is`/`errors.As`. Also replaces the bare `panic` in `New()` with `log.Panic` so startup failures go through the logger.

   No behavioral changes beyond error messages; `go build ./...` passes.